### PR TITLE
fix: Changed non-existent 'string' prompt types to 'input'

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -3,24 +3,24 @@ const { printMessage } = require('./utils')
 module.exports = {
   prompts: {
     name: {
-      type: 'string',
+      type: 'input',
       message: 'Quasar App Extension ext-id (the short name, without prefix)',
       validate: val => val && val.length > 0
     },
 
     description: {
-      type: 'string',
+      type: 'input',
       message: 'Project description',
       default: 'A Quasar App Extension'
     },
 
     author: {
-      type: 'string',
+      type: 'input',
       message: 'Author'
     },
 
     license: {
-      type: 'string',
+      type: 'input',
       message: 'License type',
       default: 'MIT'
     },
@@ -45,20 +45,20 @@ module.exports = {
     },
 
     repositoryType: {
-      type: 'string',
+      type: 'input',
       message: 'Repository type',
       default: 'git'
     },
     repositoryURL: {
-      type: 'string',
+      type: 'input',
       message: 'Repository URL (eg: https://github.com/quasarframework/quasar)'
     },
     homepage: {
-      type: 'string',
+      type: 'input',
       message: 'Homepage URL'
     },
     bugs: {
-      type: 'string',
+      type: 'input',
       message: 'Issue reporting URL (eg: https://github.com/quasarframework/quasar/issues)'
     }
   },

--- a/template/src/prompts.js
+++ b/template/src/prompts.js
@@ -12,7 +12,7 @@
   return [
     {
       name: 'name',
-      type: 'string',
+      type: 'input',
       required: true,
       message: 'Quasar CLI Extension name (without prefix)',
     },


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Refactor


**Does this PR introduce a breaking change?** (check one)

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**
There is no prompt type called `string`, the correct one is `input`. `type` defaults to `input`, that's why it was working, it's not guaranteed to work in the future too, so I have updated the usages.
See https://github.com/SBoudrias/Inquirer.js/#input---type-input